### PR TITLE
Inline anchors or images are either parsed incorrectly, or throw a PHP error (undefined offset: 6)

### DIFF
--- a/parser.php
+++ b/parser.php
@@ -2963,7 +2963,7 @@ class MarkdownLaravel_Parser extends MarkdownExtra_Parser {
 	{
 		$link_text = $this->runSpanGamut($matches[2]);
 		$url       = $matches[3] == '' ? $matches[4] : $matches[3];
-		$title     = $matches[6];
+		$title     = isset($matches[7]) ? $matches[7] : null;
 
 		$url = $this->encodeAttribute($url);
 
@@ -2998,7 +2998,7 @@ class MarkdownLaravel_Parser extends MarkdownExtra_Parser {
 	{
 		$alt_text = $matches[2];
 		$url      = $matches[3] == '' ? $matches[4] : $matches[3];
-		$title    = $matches[6];
+		$title    = isset($matches[7]) ? $matches[7] : null;
 
 		$alt_text = $this->encodeAttribute($alt_text);
 		$url = $this->encodeAttribute($url);


### PR DESCRIPTION
``` php
$text = "[Link text](http://google.com/)";
echo Sparkdown\Markdown($text);
// returns
// Unhandled Exception: undefined offset: 6
```

And

``` php
$text = "[Link text](http://google.com/ 'Title')";
echo Sparkdown\Markdown($text);
// returns
// <a href="http://google.com/" title="'">Link text</a>
```

(the same applies for inline images)

I've modified `_doAnchors_inline_callback` and `_doImages_inline_callback` to check offset 7 for the title text (not 6), and am just returning `null` if it's not present.
